### PR TITLE
Add title attribute to the list of CSS files.

### DIFF
--- a/ext/js/local/build-html.js
+++ b/ext/js/local/build-html.js
@@ -81,7 +81,7 @@ function displayForm() {
             var fail_li = "<li>" + truncateMiddle(key,60) + "</li>";
             dig_iframe.find("#cssdig-form .fail").append(fail_li);
         } else {
-            var success_li = "<li><input id='"+inputID+"' type='checkbox' value='"+ encodeURI(key) +"' checked/><label for='"+inputID+"'>" + truncateMiddle(key,60)  + "</label></li>";
+            var success_li = "<li><input id='"+inputID+"' type='checkbox' value='"+ encodeURI(key) +"' checked/><label for='"+inputID+"' title='"+key+"'>" + truncateMiddle(key,60)  + "</label></li>";
             dig_iframe.find("#cssdig-form .success").append(success_li);
         }
         inputID++


### PR DESCRIPTION
Because long CSS file names are becoming not usable, e.g.:
/Path/To/Static/Content/Css/Fi … ac-65f2-4ca9-b9ed-78a40f4123f6
