### PR TITLE
Fixed a bug where perspective prop on body of src page pushed modal offscreen

### DIFF
--- a/ext/css/dig-iframe.css
+++ b/ext/css/dig-iframe.css
@@ -21,6 +21,7 @@ html.dig #dig-blanket {
     right: 0 !important;
     top: 0 !important;
     left: 0 !important;
+    height: 100vh;
     background: rgba(255,255,255,.7) !important;
     z-index: 10000000000 !important;
 }


### PR DESCRIPTION
Fixes #6. This is actually a little bit of a hack to fix an issue that might be with WebKit, where children whose parents have the perspective CSS prop don't calculate their height properly ([demo](http://codepen.io/djmadeira/pen/JoqgGE)). There's an issue on the [WebKit bug tracker](https://bugs.webkit.org/show_bug.cgi?id=137915) if you want to make some noise about it.
