### PR TITLE
fix: allows cssdig to scroll on newer browsers

### DIFF
--- a/assets/sass/block/_layout.scss
+++ b/assets/sass/block/_layout.scss
@@ -6,6 +6,7 @@
     background: $color-background url(../i/icon48.png) 20px 20px no-repeat;
     background-size: 24px auto;
     padding: 60px 20px 20px;
+    overflow: scroll;
 }
 
 header {


### PR DESCRIPTION
### Problem
Newer browsers are preventing the result content in #cssdig element from scrolling

### Solution
Allow overflow content to scroll